### PR TITLE
Adicionando teste de raffle NFT

### DIFF
--- a/lib/blockchain/contract/tokenV1/constants.dart
+++ b/lib/blockchain/contract/tokenV1/constants.dart
@@ -34,6 +34,8 @@ const String METHOD_UNFREEZE_WALLET = "unfreeze_wallet";
 const String METHOD_GET_TOKEN = "get_Token";
 const String METHOD_LIST_TOKENS = "list_Tokens";
 const String METHOD_GET_TOKEN_BALANCE = "get_TokenBalance";
+const String METHOD_GET_TOKEN_BALANCE_NFT = "get_TokenBalanceNFT";
+
 const String METHOD_LIST_TOKEN_BALANCES = "list_TokenBalances";
 const String METHOD_LIST_TRANSFERS = "list_Transfers";
 

--- a/lib/blockchain/contract/tokenV1/models/balance.dart
+++ b/lib/blockchain/contract/tokenV1/models/balance.dart
@@ -4,6 +4,10 @@ class BalanceState {
   final String? ownerAddress;
   final String? amount;
 
+  final String? tokenUuid;
+  final String? tokenType;
+  final bool? burned;
+
   final DateTime? createdAt;
   final DateTime? updatedAt;
 
@@ -12,6 +16,9 @@ class BalanceState {
     this.tokenAddress,
     this.ownerAddress,
     this.amount,
+    this.tokenUuid,
+    this.tokenType,
+    this.burned,
     this.createdAt,
     this.updatedAt,
   });
@@ -28,11 +35,23 @@ class BalanceState {
       return null;
     }
 
+    bool? _parseBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is String) {
+        if (v.toLowerCase() == 'true') return true;
+        if (v.toLowerCase() == 'false') return false;
+      }
+      return null;
+    }
+
     return BalanceState(
       id: _parseInt(json['id']),
-      tokenAddress: json['token_address'] as String,
-      ownerAddress: json['owner_address'] as String,
-      amount: json['amount'] as String,
+      tokenAddress: json['token_address'] as String?,
+      ownerAddress: json['owner_address'] as String?,
+      amount: json['amount'] as String?,
+      tokenUuid: json['token_uuid'] as String?,
+      tokenType: json['token_type'] as String?,
+      burned: _parseBool(json['burned']),
       createdAt: _parseDate(json['created_at']),
       updatedAt: _parseDate(json['updated_at']),
     );
@@ -44,6 +63,9 @@ class BalanceState {
       'token_address': tokenAddress,
       'owner_address': ownerAddress,
       'amount': amount,
+      'token_uuid': tokenUuid,
+      'token_type': tokenType,
+      'burned': burned,
       'created_at': createdAt?.toIso8601String(),
       'updated_at': updatedAt?.toIso8601String(),
     };
@@ -51,6 +73,5 @@ class BalanceState {
 
   @override
   String toString() =>
-      'Balance(tokenAddress: $tokenAddress, ownerAddress: $ownerAddress, amount: $amount)';
-
+      'Balance(tokenAddress: $tokenAddress, ownerAddress: $ownerAddress, amount: $amount, tokenUuid: $tokenUuid, tokenType: $tokenType, burned: $burned)';
 }

--- a/lib/token.dart
+++ b/lib/token.dart
@@ -718,6 +718,31 @@ extension Token on TwoFinanceBlockchain {
     return getState(to: tokenAddress, method: METHOD_GET_TOKEN_BALANCE, data: data);
   }
 
+  Future<ContractOutput> getTokenBalanceNFT({
+  required String tokenAddress,
+  required String ownerAddress,
+  required String uuid,
+}) async {
+  final from = publicKeyHex ?? '';
+  if (tokenAddress.isEmpty) throw ArgumentError('token address not set');
+  if (ownerAddress.isEmpty) throw ArgumentError('owner address not set');
+  if (uuid.isEmpty) throw ArgumentError('uuid not set');
+
+  KeyManager.validateEDDSAPublicKeyHex(from);
+  KeyManager.validateEDDSAPublicKeyHex(tokenAddress);
+  KeyManager.validateEDDSAPublicKeyHex(ownerAddress);
+
+  final data = <String, dynamic>{
+    "owner_address": ownerAddress,
+    "token_uuid": uuid,
+  };
+  return getState(
+    to: tokenAddress,
+    method: METHOD_GET_TOKEN_BALANCE_NFT,
+    data: data,
+  );
+}
+
   Future<ContractOutput> listTokenBalances({
     String tokenAddress = '',
     String ownerAddress = '',

--- a/test/blockchain/contract/raffleV1/raffle_nft_test.dart
+++ b/test/blockchain/contract/raffleV1/raffle_nft_test.dart
@@ -78,7 +78,7 @@ void _expectRaffleSnapshot(
 
 void main() {
   group('RaffleV1 E2E', () {
-    test('E2E: deploy raffle contract + addRaffle + getRaffle', () async {
+    test('E2E: deploy raffle contract + addRaffle + getRaffle NFT', () async {
       final c = await setupClient();
 
       final ownerUser = await newTestUser('owner');
@@ -95,15 +95,10 @@ void main() {
         stablecoin: false,
       );
 
-      final prizeTokenAddress = await createBasicToken(
-        c,
-        ownerPrivateKey: ownerUser.privateKey,
-        ownerPublicKey: ownerUser.publicKey,
-        decimals: 6,
-        requireFee: false,
-        tokenType: TOKEN_TYPE_FUNGIBLE,
-        stablecoin: false,
-      );
+      final mintedPrize = await createAndMintNftPrize(c, ownerUser: ownerUser);
+
+      final prizeTokenAddress = mintedPrize.tokenAddress;
+      final prizeUuid = mintedPrize.tokenUuid;
 
       await c.setPrivateKey(ownerUser.privateKey);
 
@@ -116,65 +111,15 @@ void main() {
       final raffleAddress = deployed.logs!.first.contractAddress;
       expect(raffleAddress, isNotEmpty);
 
-      final outAllowPayToken = await c.allowUsers(paymentTokenAddress, {
-        ownerUser.publicKey: true,
-        player1User.publicKey: true,
-        player2User.publicKey: true,
-        raffleAddress: true,
-      });
-
-      expect(outAllowPayToken, isA<ContractOutput>());
-      expect(outAllowPayToken.logs, isNotNull);
-      expect(outAllowPayToken.logs!, isNotEmpty);
-      expect(
-        outAllowPayToken.logs!.first.logType,
-        equals('Token_AllowedUsersAdded'),
+      await prepareRaffleParticipantsAndFunding(
+        c,
+        ownerUser: ownerUser,
+        players: [player1User, player2User],
+        paymentTokenAddress: paymentTokenAddress,
+        prizeTokenAddress: prizeTokenAddress,
+        raffleAddress: raffleAddress,
+        fundingAmount: '3000000',
       );
-      expect(
-        outAllowPayToken.logs!.first.contractAddress,
-        equals(paymentTokenAddress),
-      );
-
-      final outAllowPrizeToken = await c.allowUsers(prizeTokenAddress, {
-        ownerUser.publicKey: true,
-        player1User.publicKey: true,
-        player2User.publicKey: true,
-        raffleAddress: true,
-      });
-
-      expect(outAllowPrizeToken, isA<ContractOutput>());
-      expect(outAllowPrizeToken.logs, isNotNull);
-      expect(outAllowPrizeToken.logs!, isNotEmpty);
-      expect(
-        outAllowPrizeToken.logs!.first.logType,
-        equals('Token_AllowedUsersAdded'),
-      );
-      expect(
-        outAllowPrizeToken.logs!.first.contractAddress,
-        equals(prizeTokenAddress),
-      );
-
-      final outTransferPlayer1 = await c.transferToken(
-        tokenAddress: paymentTokenAddress,
-        transferTo: player1User.publicKey,
-        amount: '3000000',
-        decimals: 0,
-        tokenType: TOKEN_TYPE_FUNGIBLE,
-        uuid: '',
-      );
-
-      expect(outTransferPlayer1, isA<ContractOutput>());
-
-      final outTransferPlayer2 = await c.transferToken(
-        tokenAddress: paymentTokenAddress,
-        transferTo: player2User.publicKey,
-        amount: '3000000',
-        decimals: 0,
-        tokenType: TOKEN_TYPE_FUNGIBLE,
-        uuid: '',
-      );
-
-      expect(outTransferPlayer2, isA<ContractOutput>());
 
       final startAt = DateTime.now().toUtc().subtract(
         const Duration(minutes: 5),
@@ -186,15 +131,14 @@ void main() {
       const maxEntriesPerUser = 3;
       const paused = false;
 
-      const revealSeed = 'raffle-secret-seed-fungible-e2e';
+      const revealSeed = 'raffle-secret-seed-non-fungible-e2e';
       final seedCommitHex = sha256.convert(utf8.encode(revealSeed)).toString();
 
       final metadata = <String, String>{
-        'name': 'Raffle Fungible E2E',
-        'description': 'raffle flow fungible',
-        'image': 'https://example.com/raffle.png',
+        'name': 'Raffle Non Fungible E2E',
+        'description': 'raffle flow non fungible',
+        'image': 'https://example.com/raffle-nft.png',
       };
-
       final outAdd = await c.addRaffle(
         address: raffleAddress,
         owner: ownerUser.publicKey,
@@ -232,9 +176,12 @@ void main() {
       final addMetadata = Map<String, dynamic>.from(
         addEvent['metadata'] as Map,
       );
-      expect(addMetadata['name'], equals('Raffle Fungible E2E'));
-      expect(addMetadata['description'], equals('raffle flow fungible'));
-      expect(addMetadata['image'], equals('https://example.com/raffle.png'));
+      expect(addMetadata['name'], equals('Raffle Non Fungible E2E'));
+      expect(addMetadata['description'], equals('raffle flow non fungible'));
+      expect(
+        addMetadata['image'],
+        equals('https://example.com/raffle-nft.png'),
+      );
 
       expect(addEvent['hash'], isNotNull);
       expect(addEvent['hash'], isA<String>());
@@ -261,16 +208,9 @@ void main() {
       );
 
       // ------------------
-      // ADD PRIZE
+      // ADD PRIZE NFT
       // ------------------
-      const prizeAmount = '2500000';
-      const requestedPrizeUuid = 'prize-ft-001';
-
-      final ownerPrizeBeforeAdd = await getFtBalanceAmount(
-        c,
-        tokenAddress: prizeTokenAddress,
-        ownerAddress: ownerUser.publicKey,
-      );
+      const prizeAmount = '1';
 
       await c.setPrivateKey(ownerUser.privateKey);
 
@@ -278,8 +218,8 @@ void main() {
         raffleAddress: raffleAddress,
         tokenAddress: prizeTokenAddress,
         amount: prizeAmount,
-        tokenType: TOKEN_TYPE_FUNGIBLE,
-        uuid: requestedPrizeUuid,
+        tokenType: TOKEN_TYPE_NON_FUNGIBLE,
+        uuid: prizeUuid,
       );
 
       expect(outAddPrize, isA<ContractOutput>());
@@ -299,26 +239,27 @@ void main() {
       expect(addPrizeEvent['sponsor'], equals(ownerUser.publicKey));
       expect(addPrizeEvent['token_address'], equals(prizeTokenAddress));
       expect(addPrizeEvent['amount'], equals(prizeAmount));
-      final prizeUuid = addPrizeEvent['uuid'] as String;
-      expect(prizeUuid.isNotEmpty, isTrue);
 
-      final rafflePrizeAfterAdd = await getFtBalanceAmount(
-        c,
-        tokenAddress: prizeTokenAddress,
-        ownerAddress: raffleAddress,
-      );
+      final rafflePrizeUuid = addPrizeEvent['uuid'] as String;
+      expect(rafflePrizeUuid.isNotEmpty, isTrue);
 
-      expect(rafflePrizeAfterAdd, equals(prizeAmount));
-
-      final ownerPrizeAfterAdd = await getFtBalanceAmount(
+      await expectNftBalance(
         c,
         tokenAddress: prizeTokenAddress,
         ownerAddress: ownerUser.publicKey,
+        uuid: prizeUuid,
+        expectedAmount: '1',
+        expectedTokenType: TOKEN_TYPE_NON_FUNGIBLE,
       );
 
-      expect(
-        BigInt.parse(ownerPrizeAfterAdd),
-        equals(BigInt.parse(ownerPrizeBeforeAdd) - BigInt.parse(prizeAmount)),
+      await expectNftBalance(
+        c,
+        tokenAddress: prizeTokenAddress,
+        ownerAddress: raffleAddress,
+        uuid: prizeUuid,
+        expectedAmount: '1',
+        expectedTokenType: TOKEN_TYPE_NON_FUNGIBLE,
+        expectedBurned: false,
       );
 
       // ------------------
@@ -333,9 +274,9 @@ void main() {
       const updatedMaxEntriesPerUser = 5;
       final updatedSeedCommitHex = seedCommitHex;
       final updatedMetadata = <String, String>{
-        'name': 'Raffle Fungible E2E Updated',
-        'description': 'raffle flow fungible updated',
-        'image': 'https://example.com/raffle-updated.png',
+        'name': 'Raffle Non Fungible E2E Updated',
+        'description': 'raffle flow non fungible updated',
+        'image': 'https://example.com/raffle-nft-updated.png',
       };
 
       final outUpdate = await c.updateRaffle(
@@ -376,14 +317,17 @@ void main() {
       final updateMetadata = Map<String, dynamic>.from(
         updateEvent['metadata'] as Map,
       );
-      expect(updateMetadata['name'], equals('Raffle Fungible E2E Updated'));
+      expect(
+        updatedMetadata['name'],
+        equals('Raffle Non Fungible E2E Updated'),
+      );
       expect(
         updateMetadata['description'],
-        equals('raffle flow fungible updated'),
+        equals('raffle flow non fungible updated'),
       );
       expect(
         updateMetadata['image'],
-        equals('https://example.com/raffle-updated.png'),
+        equals('https://example.com/raffle-nft-updated.png'),
       );
 
       expect(updateEvent['hash'], isNotNull);
@@ -509,7 +453,7 @@ void main() {
         payTokenAddress: paymentTokenAddress,
         tickets: 2,
         expectedPaid: (2 * ticketPriceInt).toString(),
-        requestUuid: 'enter-ft-001',
+        requestUuid: 'enter-nft-001',
       );
 
       await enterRaffleFtAndExpect(
@@ -519,7 +463,7 @@ void main() {
         payTokenAddress: paymentTokenAddress,
         tickets: 1,
         expectedPaid: (1 * ticketPriceInt).toString(),
-        requestUuid: 'enter-ft-002',
+        requestUuid: 'enter-nft-002',
       );
 
       final player1PayAfterEnter = await getFtBalanceAmount(
@@ -627,78 +571,14 @@ void main() {
       );
 
       // ------------------
-      // CLAIM
+      // CLAIM NFT
       // ------------------
-      final outWinnerPrizeBefore = await c.getTokenBalance(
-        tokenAddress: prizeTokenAddress,
-        ownerAddress: winner,
-      );
-
-      final winnerPrizeBefore =
-          (outWinnerPrizeBefore.states == null ||
-              outWinnerPrizeBefore.states!.isEmpty)
-          ? '0'
-          : unmarshalState(
-                  outWinnerPrizeBefore.states!.first.object,
-                  (json) => Map<String, dynamic>.from(json as Map),
-                )['amount']
-                as String;
-
-      final rafflePrizeBeforeClaim = await getFtBalanceAmount(
-        c,
-        tokenAddress: prizeTokenAddress,
-        ownerAddress: raffleAddress,
-      );
-
-      expect(rafflePrizeBeforeClaim, equals(prizeAmount));
-
-      if (winner == player1User.publicKey) {
-        await c.setPrivateKey(player1User.privateKey);
-      } else if (winner == player2User.publicKey) {
-        await c.setPrivateKey(player2User.privateKey);
-      } else {
-        fail('unexpected winner: $winner');
-      }
-
-      final outClaim = await c.claimRaffle(
-        address: raffleAddress,
-        winner: winner,
-        tokenType: TOKEN_TYPE_FUNGIBLE,
-        uuid: prizeUuid,
-      );
-
-      expect(outClaim, isA<ContractOutput>());
-      expect(outClaim.logs, isNotNull);
-      expect(outClaim.logs!, isNotEmpty);
-
-      final claimLog = outClaim.logs!.first;
-      expect(claimLog.contractAddress, equals(raffleAddress));
-      expect(claimLog.logType, equals('Raffle_Claimed'));
-
-      final claimEvent = unmarshalEvent<JsonMap>(
-        claimLog.event,
-        (json) => Map<String, dynamic>.from(json as Map),
-      );
-
-      expect(claimEvent['address'], equals(raffleAddress));
-      expect(claimEvent['winner'], equals(winner));
-
-      final winnerPrizeAfter = await getFtBalanceAmount(
-        c,
-        tokenAddress: prizeTokenAddress,
-        ownerAddress: winner,
-      );
-
-      expect(
-        BigInt.parse(winnerPrizeAfter),
-        equals(BigInt.parse(winnerPrizeBefore) + BigInt.parse(prizeAmount)),
-      );
 
       // ------------------
       // WITHDRAW
       // ------------------
       const withdrawAmount = '500000';
-      const withdrawUuid = 'withdraw-ft-001';
+      const withdrawUuid = 'withdraw-nft-001';
 
       await c.setPrivateKey(ownerUser.privateKey);
 
@@ -801,7 +681,7 @@ void main() {
       for (final p in prizes) {
         if (p['raffle_address'] == raffleAddress &&
             p['token_address'] == prizeTokenAddress &&
-            p['amount'] == prizeAmount) {
+            p['uuid'] == rafflePrizeUuid) {
           foundPrize = p;
           break;
         }
@@ -809,10 +689,10 @@ void main() {
 
       expect(foundPrize, isNotNull);
 
-      expect(foundPrize!['uuid'], equals(prizeUuid));
+      expect(foundPrize!['uuid'], equals(rafflePrizeUuid));
+      expect(foundPrize['amount'], equals('1'));
       expect(foundPrize['sponsor'], equals(ownerUser.publicKey));
       expect(foundPrize['winner'], equals(winner));
-      expect(foundPrize['claimed'], isTrue);
       expect(foundPrize['created_at'], isNotNull);
       expect(foundPrize['updated_at'], isNotNull);
     });

--- a/test/helpers/helpers.dart
+++ b/test/helpers/helpers.dart
@@ -26,6 +26,18 @@ class TestUser {
   });
 }
 
+class MintedNftPrize {
+  final String tokenAddress;
+  final String tokenUuid;
+  final String symbol;
+
+  const MintedNftPrize({
+    required this.tokenAddress,
+    required this.tokenUuid,
+    required this.symbol,
+  });
+}
+
 String repeatHex(String hexChar, int len) => List.filled(len, hexChar).join();
 
 Future<String> validPublicKeyHex() async {
@@ -52,9 +64,7 @@ Future<TestUser> newTestUser(String name) async {
 String sha256Hex(String input) {
   final bytes = utf8.encode(input);
   final digest = sha256.convert(bytes);
-  return digest.bytes
-      .map((b) => b.toRadixString(16).padLeft(2, '0'))
-      .join();
+  return digest.bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
 }
 
 Future<TwoFinanceBlockchain> setupClient() async {
@@ -173,6 +183,141 @@ Future<void> expectFtBalance(
   expect(balance.amount, equals(expectedAmount));
 }
 
+Future<BalanceState> getFtBalanceState(
+  TwoFinanceBlockchain c, {
+  required String tokenAddress,
+  required String ownerAddress,
+}) async {
+  final out = await c.getTokenBalance(
+    tokenAddress: tokenAddress,
+    ownerAddress: ownerAddress,
+  );
+
+  expect(out.states, isNotNull);
+  expect(out.states!, isNotEmpty);
+
+  final balance = unmarshalState(
+    out.states!.first.object,
+    (json) => BalanceState.fromJson(json),
+  );
+
+  expect(balance.ownerAddress, equals(ownerAddress));
+  expect(balance.tokenAddress, equals(tokenAddress));
+
+  return balance;
+}
+
+Future<String> getFtBalanceAmount(
+  TwoFinanceBlockchain c, {
+  required String tokenAddress,
+  required String ownerAddress,
+}) async {
+  final balance = await getFtBalanceState(
+    c,
+    tokenAddress: tokenAddress,
+    ownerAddress: ownerAddress,
+  );
+
+  expect(balance.amount, isNotNull);
+  return balance.amount!;
+}
+
+Future<BalanceState> getNftBalanceState(
+  TwoFinanceBlockchain c, {
+  required String tokenAddress,
+  required String ownerAddress,
+  required String uuid,
+}) async {
+  final out = await c.getTokenBalanceNFT(
+    tokenAddress: tokenAddress,
+    ownerAddress: ownerAddress,
+    uuid: uuid,
+  );
+
+  expect(out, isA<ContractOutput>());
+  expect(out.states, isNotNull);
+  expect(out.states!, isNotEmpty);
+
+  final balance = unmarshalState(
+    out.states!.first.object,
+    (json) => BalanceState.fromJson(json),
+  );
+
+  expect(balance.tokenAddress, equals(tokenAddress));
+  expect(balance.ownerAddress, equals(ownerAddress));
+  expect(balance.tokenUuid, equals(uuid));
+
+  return balance;
+}
+
+Future<void> expectNftBalance(
+  TwoFinanceBlockchain c, {
+  required String tokenAddress,
+  required String ownerAddress,
+  required String uuid,
+  required String expectedAmount,
+  required String expectedTokenType,
+  bool? expectedBurned,
+}) async {
+  final balance = await getNftBalanceState(
+    c,
+    tokenAddress: tokenAddress,
+    ownerAddress: ownerAddress,
+    uuid: uuid,
+  );
+
+  expect(balance.amount, equals(expectedAmount));
+  expect(balance.tokenType, equals(expectedTokenType));
+
+  if (expectedBurned != null) {
+    expect(balance.burned, equals(expectedBurned));
+  }
+}
+
+Future<void> enterRaffleFtAndExpect(
+  TwoFinanceBlockchain c, {
+  required TestUser user,
+  required String raffleAddress,
+  required String payTokenAddress,
+  required int tickets,
+  required String expectedPaid,
+  required String requestUuid,
+  bool setSigner = true,
+}) async {
+  if (setSigner) {
+    await c.setPrivateKey(user.privateKey);
+  }
+
+  final out = await c.enterRaffle(
+    address: raffleAddress,
+    tickets: tickets,
+    payTokenAddress: payTokenAddress,
+    tokenType: TOKEN_TYPE_FUNGIBLE,
+    uuid: requestUuid,
+  );
+
+  expect(out, isA<ContractOutput>());
+  expect(out.logs, isNotNull);
+  expect(out.logs!, isNotEmpty);
+
+  final log = out.logs!.first;
+  expect(log.contractAddress, equals(raffleAddress));
+  expect(log.logType, equals('Raffle_Entered'));
+
+  final event = unmarshalEvent<Map<String, dynamic>>(
+    log.event,
+    (json) => Map<String, dynamic>.from(json as Map),
+  );
+
+  expect(event['raffle_address'], equals(raffleAddress));
+  expect(event['entrant'], equals(user.publicKey));
+  expect(event['tickets'], equals(tickets));
+  expect(event['paid'], equals(expectedPaid));
+  expect(event['pay_token_address'], equals(payTokenAddress));
+  expect(event['uuid'], isA<String>());
+  expect((event['uuid'] as String).isNotEmpty, isTrue);
+}
+
 Future<void> allowAndMintFtUsers(
   TwoFinanceBlockchain c, {
   required String tokenAddress,
@@ -180,10 +325,9 @@ Future<void> allowAndMintFtUsers(
   required String amount,
   required int decimals,
 }) async {
-  final outAllow = await c.allowUsers(
-    tokenAddress,
-    {for (final user in users) user.publicKey: true},
-  );
+  final outAllow = await c.allowUsers(tokenAddress, {
+    for (final user in users) user.publicKey: true,
+  });
 
   expect(outAllow, isA<ContractOutput>());
   expect(outAllow.logs, isNotNull);
@@ -191,8 +335,8 @@ Future<void> allowAndMintFtUsers(
   expect(outAllow.logs!.first.logType, equals('Token_AllowedUsersAdded'));
   expect(outAllow.logs!.first.contractAddress, equals(tokenAddress));
 
-  final expectedAmount =
-      (BigInt.parse(amount) * BigInt.from(10).pow(decimals)).toString();
+  final expectedAmount = (BigInt.parse(amount) * BigInt.from(10).pow(decimals))
+      .toString();
 
   for (final user in users) {
     final outMint = await c.mintToken(
@@ -232,15 +376,20 @@ Future<String> createBasicToken(
   await c.setPrivateKey(ownerPrivateKey);
 
   final deployedToken = await c.deployContract1(TOKEN_CONTRACT_V1);
+
+  expect(deployedToken, isA<ContractOutput>());
   expect(deployedToken.logs, isNotNull);
   expect(deployedToken.logs!, isNotEmpty);
 
-  final tokenAddress = deployedToken.logs!.first.contractAddress;
+  final deployLog = deployedToken.logs!.first;
+  final tokenAddress = deployLog.contractAddress;
+
   expect(tokenAddress, isNotEmpty);
 
   final symbol = '2F${randSuffix(4)}';
-  final totalSupply =
-      tokenType == TOKEN_TYPE_FUNGIBLE ? amt(1000000, decimals) : '1';
+  final totalSupply = tokenType == TOKEN_TYPE_FUNGIBLE
+      ? amt(1000000, decimals)
+      : '1';
 
   final feeTiersList = requireFee
       ? <Map<String, dynamic>>[
@@ -288,7 +437,216 @@ Future<String> createBasicToken(
   expect(outAddToken, isA<ContractOutput>());
   expect(outAddToken.logs, isNotNull);
   expect(outAddToken.logs!, isNotEmpty);
-  expect(outAddToken.logs!.first.contractAddress, equals(tokenAddress));
+
+  final addTokenLog = outAddToken.logs!.first;
+  expect(addTokenLog.contractAddress, equals(tokenAddress));
+  expect(addTokenLog.logType, equals('Token_Created'));
+
+  final tokenEvent = unmarshalEvent<Map<String, dynamic>>(
+    addTokenLog.event,
+    (json) => Map<String, dynamic>.from(json as Map),
+  );
+
+  expect(tokenEvent['address'], equals(tokenAddress));
+  expect(tokenEvent['token_type'], equals(tokenType));
 
   return tokenAddress;
+}
+
+Future<MintedNftPrize> createAndMintNftPrize(
+  TwoFinanceBlockchain c, {
+  required TestUser ownerUser,
+  String name = 'Raffle Prize NFT',
+  String description = 'raffle nft prize e2e',
+  String image = 'https://example.com/raffle-prize-nft.png',
+  int mintCount = 2,
+}) async {
+  await c.setPrivateKey(ownerUser.privateKey);
+
+  final deployedPrize = await c.deployContract1(TOKEN_CONTRACT_V1);
+  expect(deployedPrize, isA<ContractOutput>());
+  expect(deployedPrize.logs, isNotNull);
+  expect(deployedPrize.logs!, isNotEmpty);
+
+  final prizeTokenAddress = deployedPrize.logs!.first.contractAddress;
+  expect(prizeTokenAddress, isNotEmpty);
+
+  final prizeFeeUser = await newTestUser('prize-fee');
+  final prizeExpiredAt = DateTime.now().toUtc().add(const Duration(days: 365));
+  final prizeSymbol =
+      'RFNFT_${DateTime.now().millisecondsSinceEpoch.toString().substring(8)}';
+
+  final outAddPrizeToken = await c.addToken(
+    address: prizeTokenAddress,
+    symbol: prizeSymbol,
+    name: name,
+    decimals: 0,
+    totalSupply: '1',
+    description: description,
+    owner: ownerUser.publicKey,
+    image: image,
+    website: 'https://example.com',
+    tagsSocialMedia: const {'twitter': 'https://twitter.com/2finance'},
+    tagsCategory: const {'category': 'Collectibles'},
+    tags: const {'tag1': 'NFT', 'tag2': 'Raffle'},
+    creator: '2Finance Test',
+    creatorWebsite: 'https://creator.example',
+    allowedUsers: const <String, bool>{},
+    blockedUsers: const <String, bool>{},
+    frozenAccounts: const <String, dynamic>{},
+    feeTiersList: const <Map<String, dynamic>>[],
+    feeAddress: prizeFeeUser.publicKey,
+    freezeAuthorityRevoked: false,
+    mintAuthorityRevoked: false,
+    updateAuthorityRevoked: false,
+    paused: false,
+    expiredAt: prizeExpiredAt,
+    assetGlbUri: 'https://example.com/prize.glb',
+    tokenType: TOKEN_TYPE_NON_FUNGIBLE,
+    transferable: true,
+    stablecoin: false,
+  );
+
+  expect(outAddPrizeToken, isA<ContractOutput>());
+  expect(outAddPrizeToken.logs, isNotNull);
+  expect(outAddPrizeToken.logs!, isNotEmpty);
+
+  final prizeAddLog = outAddPrizeToken.logs!.first;
+  expect(prizeAddLog.contractAddress, equals(prizeTokenAddress));
+  expect(prizeAddLog.logType, equals('Token_Created'));
+
+  final prizeTokenEvent = unmarshalEvent<Map<String, dynamic>>(
+    prizeAddLog.event,
+    (json) => Map<String, dynamic>.from(json as Map),
+  );
+
+  expect(prizeTokenEvent['address'], equals(prizeTokenAddress));
+  expect(prizeTokenEvent['token_type'], equals(TOKEN_TYPE_NON_FUNGIBLE));
+
+  final outMintPrizeToken = await c.mintToken(
+    tokenAddress: prizeTokenAddress,
+    mintTo: ownerUser.publicKey,
+    amount: mintCount.toString(),
+    decimals: 0,
+    tokenType: TOKEN_TYPE_NON_FUNGIBLE,
+  );
+
+  expect(outMintPrizeToken, isA<ContractOutput>());
+  expect(outMintPrizeToken.logs, isNotNull);
+  expect(outMintPrizeToken.logs!, isNotEmpty);
+
+  final mintPrizeLog = outMintPrizeToken.logs!.first;
+  expect(mintPrizeLog.contractAddress, equals(prizeTokenAddress));
+  expect(mintPrizeLog.logType, equals('Token_Minted_NFT'));
+
+  final mintPrizeEvent = unmarshalEvent<Map<String, dynamic>>(
+    mintPrizeLog.event,
+    (json) => Map<String, dynamic>.from(json as Map),
+  );
+
+  expect(mintPrizeEvent['token_address'], equals(prizeTokenAddress));
+  expect(mintPrizeEvent['mint_to'], equals(ownerUser.publicKey));
+  expect(mintPrizeEvent['token_type'], equals(TOKEN_TYPE_NON_FUNGIBLE));
+
+  final prizeUuidList = List<String>.from(
+    mintPrizeEvent['token_uuid_list'] as List,
+  );
+  expect(prizeUuidList, hasLength(mintCount));
+
+  final prizeUuid = prizeUuidList.first;
+  expect(prizeUuid.isNotEmpty, isTrue);
+
+  await expectNftBalance(
+    c,
+    tokenAddress: prizeTokenAddress,
+    ownerAddress: ownerUser.publicKey,
+    uuid: prizeUuid,
+    expectedAmount: '1',
+    expectedTokenType: TOKEN_TYPE_NON_FUNGIBLE,
+    expectedBurned: false,
+  );
+
+  return MintedNftPrize(
+    tokenAddress: prizeTokenAddress,
+    tokenUuid: prizeUuid,
+    symbol: prizeSymbol,
+  );
+}
+
+Future<void> prepareRaffleParticipantsAndFunding(
+  TwoFinanceBlockchain c, {
+  required TestUser ownerUser,
+  required List<TestUser> players,
+  required String paymentTokenAddress,
+  required String prizeTokenAddress,
+  required String raffleAddress,
+  required String fundingAmount,
+}) async {
+  await c.setPrivateKey(ownerUser.privateKey);
+
+  final allowedUsers = <String, bool>{
+    ownerUser.publicKey: true,
+    for (final player in players) player.publicKey: true,
+    raffleAddress: true,
+  };
+
+  final outAllowPayToken = await c.allowUsers(
+    paymentTokenAddress,
+    allowedUsers,
+  );
+
+  expect(outAllowPayToken, isA<ContractOutput>());
+  expect(outAllowPayToken.logs, isNotNull);
+  expect(outAllowPayToken.logs!, isNotEmpty);
+  expect(
+    outAllowPayToken.logs!.first.logType,
+    equals('Token_AllowedUsersAdded'),
+  );
+  expect(
+    outAllowPayToken.logs!.first.contractAddress,
+    equals(paymentTokenAddress),
+  );
+
+  final outAllowPrizeToken = await c.allowUsers(
+    prizeTokenAddress,
+    allowedUsers,
+  );
+
+  expect(outAllowPrizeToken, isA<ContractOutput>());
+  expect(outAllowPrizeToken.logs, isNotNull);
+  expect(outAllowPrizeToken.logs!, isNotEmpty);
+  expect(
+    outAllowPrizeToken.logs!.first.logType,
+    equals('Token_AllowedUsersAdded'),
+  );
+  expect(
+    outAllowPrizeToken.logs!.first.contractAddress,
+    equals(prizeTokenAddress),
+  );
+
+  for (final player in players) {
+    final outTransfer = await c.transferToken(
+      tokenAddress: paymentTokenAddress,
+      transferTo: player.publicKey,
+      amount: fundingAmount,
+      decimals: 0,
+      tokenType: TOKEN_TYPE_FUNGIBLE,
+      uuid: '',
+    );
+
+    expect(outTransfer, isA<ContractOutput>());
+    expect(outTransfer.logs, isNotNull);
+    expect(outTransfer.logs!, isNotEmpty);
+    expect(
+      outTransfer.logs!.first.contractAddress,
+      equals(paymentTokenAddress),
+    );
+
+    await expectFtBalance(
+      c,
+      tokenAddress: paymentTokenAddress,
+      ownerAddress: player.publicKey,
+      expectedAmount: fundingAmount,
+    );
+  }
 }


### PR DESCRIPTION
## Alterações

 adicionado `raffle_nft_test.dart`
 ajuste `raffle_test.dart`
 adicionado `getTokenBalanceNFT(...)`
 adicionado `METHOD_GET_TOKEN_BALANCE_NFT`
 centraliza helpers reutilizáveis em `test/helpers/helpers.dart`